### PR TITLE
fix(supports-metadata): add missing checks

### DIFF
--- a/contracts/hooks/aggregation/src/main.sw
+++ b/contracts/hooks/aggregation/src/main.sw
@@ -70,7 +70,7 @@ impl PostDispatchHook for Contract {
     ///
     /// * [bool] - Whether the hook supports the metadata.
     fn supports_metadata(metadata: Bytes) -> bool {
-        StandardHookMetadata::is_valid(metadata)
+        _supports_metadata(metadata)
     }
 
     /// Compute the payment required by the postDispatch call
@@ -85,6 +85,7 @@ impl PostDispatchHook for Contract {
     /// * [u64] - The payment required for the postDispatch call.
     #[storage(read)]
     fn quote_dispatch(metadata: Bytes, message: Bytes) -> u64 {
+        require(_supports_metadata(metadata), PostDispatchHookError::InvalidMetadata);
         let hooks = storage.hooks.load_vec();
 
         let mut total = 0;
@@ -106,6 +107,7 @@ impl PostDispatchHook for Contract {
     #[payable]
     #[storage(read, write)]
     fn post_dispatch(metadata: Bytes, message: Bytes) {
+        require(_supports_metadata(metadata), PostDispatchHookError::InvalidMetadata);
         let hooks = storage.hooks.load_vec();
 
         let mut i = 0;
@@ -129,7 +131,9 @@ impl PostDispatchHook for Contract {
 // ------------------ Internal Functions ----------------------
 // ------------------------------------------------------------
 
-
+fn _supports_metadata(metadata: Bytes) -> bool {
+    StandardHookMetadata::is_valid(metadata)
+}
 
 fn _hook_quote_dispatch(hook: ContractId, metadata: Bytes, message: Bytes) -> u64 {
     let hook_contract = abi(PostDispatchHook, hook.bits());

--- a/contracts/hooks/merkle-tree-hook/Forc.toml
+++ b/contracts/hooks/merkle-tree-hook/Forc.toml
@@ -8,3 +8,4 @@ name = "merkle-tree-hook"
 interfaces = { path = "../../interfaces" }
 merkle = { path = "../../libs/merkle" }
 message = { path = "../../libs/message" }
+std_hook_metadata = { path = "../../libs/std-hook-metadata" }

--- a/contracts/hooks/merkle-tree-hook/src/main.sw
+++ b/contracts/hooks/merkle-tree-hook/src/main.sw
@@ -5,6 +5,7 @@ use message::EncodedMessage;
 use std::storage::storage_vec::*;
 use std::{block::height, bytes::Bytes, context::msg_amount};
 use interfaces::{mailbox::mailbox::*, hooks::{merkle_tree_hook::*, post_dispatch_hook::*}};
+use std_hook_metadata::{StandardHookMetadata};
 
 storage {
     merkle_tree: StorageMerkleTree = StorageMerkleTree {},
@@ -98,8 +99,9 @@ impl PostDispatchHook for Contract {
     /// ### Returns
     ///
     /// * [bool] - Whether the hook supports the metadata.
-    fn supports_metadata(_metadata: Bytes) -> bool {
-        false
+    fn supports_metadata(metadata: Bytes) -> bool {
+        // We perform the same check as EVM for compatibility
+        StandardHookMetadata::is_valid(metadata)
     }
 
     /// Post action after a message is dispatched via the Mailbox

--- a/contracts/hooks/pausable-hook/Forc.toml
+++ b/contracts/hooks/pausable-hook/Forc.toml
@@ -8,3 +8,4 @@ name = "pausable-hook"
 interfaces = { path = "../../interfaces" }
 sway_libs = { git = "https://github.com/fuellabs/sway-libs", branch = "master" }
 standards = { git = "https://github.com/FuelLabs/sway-standards", branch = "master" }
+std_hook_metadata = { path = "../../libs/std-hook-metadata" }

--- a/contracts/hooks/pausable-hook/src/main.sw
+++ b/contracts/hooks/pausable-hook/src/main.sw
@@ -6,6 +6,7 @@ use interfaces::{
 };
 use standards::src5::State;
 use sway_libs::{ownership::*, pausable::*};
+use std_hook_metadata::{StandardHookMetadata};
 use std::{bytes::Bytes};
 
 impl PostDispatchHook for Contract {
@@ -27,8 +28,9 @@ impl PostDispatchHook for Contract {
     /// ### Returns
     ///
     /// * [bool] - Whether the hook supports the metadata.
-    fn supports_metadata(_metadata: Bytes) -> bool {
-        false
+    fn supports_metadata(metadata: Bytes) -> bool {
+        // We perform the same check as EVM for compatibility
+        StandardHookMetadata::is_valid(metadata)
     }
 
     /// Post action after a message is dispatched via the Mailbox

--- a/contracts/hooks/pausable-hook/tests/harness.rs
+++ b/contracts/hooks/pausable-hook/tests/harness.rs
@@ -86,7 +86,7 @@ async fn post_dispatch_interface() {
         .unwrap()
         .value;
 
-    assert!(!supports_metadata);
+    assert!(supports_metadata);
 
     // Post dispatch
     let post_dispatch = hook

--- a/contracts/interfaces/src/hooks/post_dispatch_hook.sw
+++ b/contracts/interfaces/src/hooks/post_dispatch_hook.sw
@@ -2,6 +2,10 @@ library;
 
 use std::bytes::Bytes;
 
+pub enum PostDispatchHookError {
+    InvalidMetadata: (),
+}
+
 /// Types of post dispatch hooks.
 pub enum PostDispatchHookType {
     UNUSED: (),


### PR DESCRIPTION
Audit finding No 9

```
Discrepancies in Metadata Handling Between Solidity and Sway Implementations
```