### PR TITLE
fix(warp-route): set decimals access control

### DIFF
--- a/contracts/warp-route/src/main.sw
+++ b/contracts/warp-route/src/main.sw
@@ -595,6 +595,7 @@ impl TokenRouter for Contract {
     /// * `decimals`: [u8] - The decimals to set
     #[storage(write)]
     fn set_remote_router_decimals(router: b256, decimals: u8) {
+        only_owner();
         storage.remote_router_decimals.insert(router, decimals);
     }
 }


### PR DESCRIPTION
Audit finding No 10

```
Missing access control in set_remote_router_decimals allows arbitrary decimals manipulation
```