### PR TITLE
Fix/multisig ism loop

### DIFF
--- a/contracts/ism/multisig/merkle-root-multisig-ism/src/main.sw
+++ b/contracts/ism/multisig/merkle-root-multisig-ism/src/main.sw
@@ -88,7 +88,7 @@ impl InterchainSecurityModule for Contract {
             let signer = address_recover_result.unwrap();
 
             // Loop through remaining validators until we find a match
-            while u64::from(validator_index) < validator_count && signer != storage.validators.get(validator_index).unwrap().read() {
+            while validator_index < validator_count && signer != storage.validators.get(validator_index).unwrap().read() {
                 validator_index += 1;
             }
 

--- a/contracts/ism/multisig/merkle-root-multisig-ism/src/main.sw
+++ b/contracts/ism/multisig/merkle-root-multisig-ism/src/main.sw
@@ -66,10 +66,10 @@ impl InterchainSecurityModule for Contract {
         require(threshold > 0, MerkleRootMultisigError::NoMultisigThreshold);
 
         let validator_count = validators.len();
-        let mut validator_index: u8 = 0;
-        let mut loop_index: u8 = 0;
-        while loop_index < threshold {
-            let signature_recover_result = _signature_at(metadata, u32::from(loop_index));
+        let mut validator_index: u64 = 0;
+        let mut loop_index: u32 = 0;
+        while loop_index < u32::from(threshold) {
+            let signature_recover_result = _signature_at(metadata, loop_index);
             let sig_transformed = signature_recover_result.to_compact_signature();
             require(
                 sig_transformed
@@ -88,13 +88,13 @@ impl InterchainSecurityModule for Contract {
             let signer = address_recover_result.unwrap();
 
             // Loop through remaining validators until we find a match
-            while u64::from(validator_index) < validator_count && signer != storage.validators.get(u64::from(validator_index)).unwrap().read() {
+            while u64::from(validator_index) < validator_count && signer != storage.validators.get(validator_index).unwrap().read() {
                 validator_index += 1;
             }
 
             // Fail if we never found a match
             require(
-                u64::from(validator_index) < validator_count,
+                validator_index < validator_count,
                 MerkleRootMultisigError::NoValidatorMatch,
             );
 

--- a/contracts/ism/multisig/message-id-multisig-ism/src/main.sw
+++ b/contracts/ism/multisig/message-id-multisig-ism/src/main.sw
@@ -66,10 +66,10 @@ impl InterchainSecurityModule for Contract {
         require(threshold > 0, MessageIdMultisigError::NoMultisigThreshold);
 
         let validator_count = validators.len();
-        let mut validator_index: u8 = 0;
-        let mut loop_index: u8 = 0;
-        while loop_index < threshold {
-            let signature_recover_result = _signature_at(metadata, u32::from(loop_index));
+        let mut validator_index: u64 = 0;
+        let mut loop_index: u32 = 0;
+        while loop_index < u32::from(threshold) {
+            let signature_recover_result = _signature_at(metadata, loop_index);
             let sig_transformed = signature_recover_result.to_compact_signature();
             require(
                 sig_transformed
@@ -88,13 +88,13 @@ impl InterchainSecurityModule for Contract {
             let signer = address_recover_result.unwrap();
 
             // Loop through remaining validators until we find a match
-            while u64::from(validator_index) < validator_count && signer != storage.validators.get(u64::from(validator_index)).unwrap().read() {
+            while validator_index < validator_count && signer != storage.validators.get(validator_index).unwrap().read() {
                 validator_index += 1;
             }
 
             // Fail if we never found a match
             require(
-                u64::from(validator_index) < validator_count,
+                validator_index < validator_count,
                 MessageIdMultisigError::NoValidatorMatch,
             );
 


### PR DESCRIPTION
Audit finding No 12

```
Loop counter precision issue in multisig ISM implementations
```

integers don't overflow, but if we bump them up more we support more than 256 validators and less number conversions making it nicer a bit