### PR TITLE
Revert on invalid removal, return mailbox module on fallback module query

### DIFF
--- a/contracts/interfaces/src/isms/routing/default_fallback_domain_routing_ism.sw
+++ b/contracts/interfaces/src/isms/routing/default_fallback_domain_routing_ism.sw
@@ -2,6 +2,7 @@ library;
 
 pub enum DefaultFallbackDomainRoutingIsmError {
     DomainModuleLengthMismatch:(u64, u64),
+    DomainNotSet: u32,
 }
 
 abi DefaultFallbackDomainRoutingIsm {

--- a/contracts/ism/routing/default-fallback-domain-routing-ism/src/main.sw
+++ b/contracts/ism/routing/default-fallback-domain-routing-ism/src/main.sw
@@ -150,10 +150,12 @@ impl DefaultFallbackDomainRoutingIsm for Contract {
     #[storage(write, read)]
     fn remove(domain: u32) {
         only_owner();
-        let success = storage.domain_modules.remove(domain);
-        if success {
-            _remove_domain(domain);
-        }
+        require(
+            storage.domain_modules.remove(domain),
+            DefaultFallbackDomainRoutingIsmError::DomainNotSet(domain),
+        );
+        _remove_domain(domain);
+
     }
 
     /// Returns the domains that have been set
@@ -177,7 +179,13 @@ impl DefaultFallbackDomainRoutingIsm for Contract {
     /// * [b256] - The ISM to be used for the specified domain.
     #[storage(read)]
     fn module(domain: u32) -> b256 {
-        storage.domain_modules.get(domain).try_read().unwrap_or(b256::zero())
+        let module = storage.domain_modules.get(domain).try_read();
+        if module.is_some() {
+            return module.unwrap();
+        }
+        let mailbox_id = storage.mailbox.read();
+        let mailbox = abi(Mailbox, mailbox_id);
+        <b256 as From<ContractId>>::from(mailbox.default_ism())
     }
 
     /// Returns the fallback mailbox for the ISM

--- a/contracts/ism/routing/domain-routing-ism/src/main.sw
+++ b/contracts/ism/routing/domain-routing-ism/src/main.sw
@@ -135,10 +135,11 @@ impl DomainRoutingIsm for Contract {
     #[storage(write, read)]
     fn remove(domain: u32) {
         only_owner();
-        let success = storage.domain_modules.remove(domain);
-        if success {
-            _remove_domain(domain);
-        }
+        require(
+            storage.domain_modules.remove(domain),
+            DomainRoutingIsmError::DomainNotSet(domain),
+        );
+        _remove_domain(domain);
     }
 
     /// Returns the domains that have been set


### PR DESCRIPTION
Audit finding No 14

```
Domain routing ISM does not validate domain existence
```