### PR TITLE
fix(merkle-hook): prevent zero address init calls

### DIFF
--- a/contracts/hooks/merkle-tree-hook/src/main.sw
+++ b/contracts/hooks/merkle-tree-hook/src/main.sw
@@ -27,6 +27,10 @@ impl MerkleTreeHook for Contract {
             !_is_initialized(),
             MerkleTreeHookError::ContractAlreadyInitialized,
         );
+        require(
+            mailbox != ContractId::zero(),
+            MerkleTreeHookError::CannotInitializeWithZeroAddress,
+        );
         storage.mailbox.write(mailbox);
     }
 

--- a/contracts/interfaces/src/hooks/merkle_tree_hook.sw
+++ b/contracts/interfaces/src/hooks/merkle_tree_hook.sw
@@ -62,4 +62,5 @@ pub enum MerkleTreeHookError {
     NoValueExpected: (),
     ContractNotInitialized: (),
     ContractAlreadyInitialized: (),
+    CannotInitializeWithZeroAddress: (),
 }


### PR DESCRIPTION
Audit finding No 17

```
Lack of Sender Validation in Initialization Functions Leading to Potential Front-Running Risk
```


^^ issue desc pretty bad