### PR TITLE
fix(igp): avoid conversion decimal overflow

### DIFF
--- a/contracts/hooks/gas-paymaster/src/main.sw
+++ b/contracts/hooks/gas-paymaster/src/main.sw
@@ -486,14 +486,14 @@ fn convert_decimals(num: u256, from_decimals: u8, to_decimals: u8) -> u256 {
     if from_decimals > to_decimals {
         let diff: u64 = (from_decimals - to_decimals).as_u64();
         let diff_u32 = diff.try_as_u32().expect("Conversion to u32 failed");
-        let divisor = 10u64.pow(diff_u32).as_u256();
+        let divisor = u256::from(10u64).pow(diff_u32);
 
         require(divisor != 0, "Divisor cannot be zero");
         num / divisor
     } else {
         let diff: u64 = (to_decimals - from_decimals).as_u64();
         let diff_u32 = diff.try_as_u32().expect("Conversion to u32 failed");
-        let multiplier = 10u64.pow(diff_u32).as_u256();
+        let multiplier = u256::from(10u64).pow(diff_u32);
 
         require(multiplier != 0, "Multiplier cannot be zero");
         num * multiplier
@@ -533,4 +533,38 @@ fn test_convert_decimals() {
     let to_decimals = 4;
     let result = convert_decimals(num, from_decimals, to_decimals);
     assert(result == u256::from((0, 0, 0, 0)));
+
+    // Edge decimal cases
+    let num = u256::from(18u64);
+    let from_decimals = 6;
+    let to_decimals = 24;
+    let result = convert_decimals(num, from_decimals, to_decimals);
+    assert(u256_to_u64(result).is_some());
+
+    let num = u256::from(19u64);
+    let from_decimals = 6;
+    let to_decimals = 24;
+    let result = convert_decimals(num, from_decimals, to_decimals);
+    assert(u256_to_u64(result).is_none());
+
+    // Expected max `to_decimals`
+    let num = u256::from(18_446_744u64);
+    let from_decimals = 6;
+    let to_decimals = 18;
+    let result = convert_decimals(num, from_decimals, to_decimals);
+    assert(u256_to_u64(result).is_some());
+
+    let num = u256::from(18_446_745u64);
+    let from_decimals = 6;
+    let to_decimals = 18;
+    let result = convert_decimals(num, from_decimals, to_decimals);
+    assert(u256_to_u64(result).is_none());
+
+    // going from very large numbers to low precision is not problematic
+    // 18_446_744_073_709_551_615_999_999_999_999_999_999
+    let num = u256::from((0u64, 0u64, 0x0DE0B6B3A763FFFFu64, 0xFFFFFFFFFFFFFFFFu64));
+    let from_decimals = 24;
+    let to_decimals = 6;
+    let result = convert_decimals(num, from_decimals, to_decimals);
+    assert(u256_to_u64(result).is_some());
 }


### PR DESCRIPTION
Audit finding No 11

```
Potential overflow in decimal conversion due to u64 exponentiation
```